### PR TITLE
Fix Collider Issue With Ship Laser

### DIFF
--- a/Assets/Prefabs/Asteroid.prefab
+++ b/Assets/Prefabs/Asteroid.prefab
@@ -103,7 +103,7 @@ Rigidbody2D:
   m_Material: {fileID: 0}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 0
 --- !u!61 &2815407648983029046
 BoxCollider2D:
@@ -129,7 +129,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.9, y: 0.9}
+  m_Size: {x: 0.7, y: 0.7}
   m_EdgeRadius: 0
 --- !u!114 &5583036249363727355
 MonoBehaviour:

--- a/Assets/Prefabs/Ship/Projectiles/ShipLaser.prefab
+++ b/Assets/Prefabs/Ship/Projectiles/ShipLaser.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8d69f024a169cd745880c88c212051e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  velY: 30
+  velY: 10
 --- !u!212 &4323674457895942765
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Asteroid/AsteroidMovement.cs
+++ b/Assets/Scripts/Asteroid/AsteroidMovement.cs
@@ -9,7 +9,7 @@ public class AsteroidMovement : MonoBehaviour
 
     float RandomNum;
     private const float velX = 0;
-    public float velY = -1f;
+    public float velY = -3f;
     Rigidbody2D rb;
     int asteroidHealth = 10;
 

--- a/Assets/Scripts/Power-ups/BulletsPowerUp.cs
+++ b/Assets/Scripts/Power-ups/BulletsPowerUp.cs
@@ -6,7 +6,7 @@ public class BulletsPowerUp : MonoBehaviour
 {
     Rigidbody2D rb;
     private const float velX = 0;
-    public float velY = -1f;
+    public float velY = -3f;
     void Start()
     {
         rb = GetComponent<Rigidbody2D>();
@@ -19,7 +19,8 @@ public class BulletsPowerUp : MonoBehaviour
     }
     private void OnCollisionEnter2D(Collision2D col)
     {
-        if (col.gameObject.CompareTag("Ship")) {
+        if (col.gameObject.CompareTag("Ship"))
+        {
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/Ship/PlayerShoot.cs
+++ b/Assets/Scripts/Ship/PlayerShoot.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 public class PlayerShoot : MonoBehaviour
 {
     public GameObject ShipBullet;
-    public float delayTime = 0.25f;
+    public float delayTime = 0.20f;
     bool canShoot = true;
     public AudioSource audioData;
 
@@ -27,7 +27,7 @@ public class PlayerShoot : MonoBehaviour
         }
         if (col.gameObject.CompareTag("EnemyBullet") || col.gameObject.CompareTag("GreenEnemy") || col.gameObject.CompareTag("Asteroid"))
         {
-            delayTime = 0.25f;
+            delayTime = 0.20f;
         }
     }
 


### PR DESCRIPTION
Changed delay time of laser to 0.20 to make it consistent with what is in the inspector. Increased speed of asteroid from 1 to 3.  Made collision box for asteroids more accurate. The solution to the collision issue seems to be a lower velocity for the ship laser, and 10 appears to be the ideal number for this.