### PR TITLE
All asteroids should drop powerups

### DIFF
--- a/Assets/Scripts/Asteroid/Asteroid.cs
+++ b/Assets/Scripts/Asteroid/Asteroid.cs
@@ -16,17 +16,15 @@ public class Asteroid : MonoBehaviour
 
     Rigidbody2D rb;
 
-    int asteroidHealth = 10;
+    int asteroidHealth = 5;
 
     bool canAppear = true;
 
     float powerUpDelay = 1.0f;
 
-    float bulletsPowerUpChance = 0.5f;
+    float bulletsPowerUpChance = 1;
 
-    float healthPowerUpChance = 0.5f;
-
-    float shieldPowerUpChance = 0.5f;
+    float healthPowerUpChance = 2;
 
     AudioSource[] audioSources;
 
@@ -65,8 +63,7 @@ public class Asteroid : MonoBehaviour
                 AudioSource.PlayClipAtPoint(explosionSound, new Vector2(0, 0));
 
                 Destroy(gameObject);
-
-                if (Random.Range(0.00f, 1.00f) < bulletsPowerUpChance && canAppear)
+                if (Random.Range(1, 3) == bulletsPowerUpChance && canAppear)
                 {
                     Instantiate(BulletsPowerUp,
                     transform.position,
@@ -74,11 +71,7 @@ public class Asteroid : MonoBehaviour
                     canAppear = false;
                     StartCoroutine(NoAppear());
                 }
-                if (
-                    Random.Range(0.00f, 1.00f) < healthPowerUpChance &&
-                    shipHealth < 10 &&
-                    canAppear
-                )
+                else if (Random.Range(1, 3) == healthPowerUpChance && canAppear)
                 {
                     Instantiate(HealthPowerUp,
                     transform.position,
@@ -86,9 +79,11 @@ public class Asteroid : MonoBehaviour
                     canAppear = false;
                     StartCoroutine(NoAppear());
                 }
-                if (Random.Range(0.00f, 1.00f) < shieldPowerUpChance && canAppear && Ship.shield == false)
+                else
                 {
-                    Instantiate(ShieldPowerUp, transform.position, transform.rotation);
+                    Instantiate(ShieldPowerUp,
+                    transform.position,
+                    transform.rotation);
                     canAppear = false;
                     StartCoroutine(NoAppear());
                 }

--- a/Assets/Scripts/Enemy/EnemyLaser.cs
+++ b/Assets/Scripts/Enemy/EnemyLaser.cs
@@ -26,7 +26,8 @@ public class EnemyLaser : MonoBehaviour
         //     Physics.IgnoreCollision(GetComponent<Collider>(), GetComponent<Collider>());
         // }
         if (col.gameObject.CompareTag("Ship") ||
-            col.gameObject.CompareTag("Shield"))
+            col.gameObject.CompareTag("Shield") ||
+            col.gameObject.CompareTag("Asteroid"))
         {
             Destroy(gameObject);
         }

--- a/Assets/Scripts/Ship/ShipShoot.cs
+++ b/Assets/Scripts/Ship/ShipShoot.cs
@@ -31,7 +31,7 @@ public class ShipShoot : MonoBehaviour
             multiplier--;
             multiplierTimer = 4.0f;
         }
-        shootDelayTime = 0.50f / multiplier;
+        shootDelayTime = 0.40f / multiplier;
         if (!canShoot) return;
         canShoot = false;
         StartCoroutine(NoFire());

--- a/Assets/Scripts/Utility/RandomHandler.cs
+++ b/Assets/Scripts/Utility/RandomHandler.cs
@@ -9,6 +9,6 @@ public static class RandomHandler
 
     public static double AsteroidRandomAppear()
     {
-        return random.NextDouble() * 20.92756195672f;
+        return random.NextDouble() * 25.92756195672f;
     }
 }


### PR DESCRIPTION
Made asteroid always spawn a power up and decreased frequency that asteroids spawn to balance it out.  Enemy lasers are destroyed when in contact with asteroids. Slightly increased ship laser speed so asteroid can be destroyed at 1x multiplier.